### PR TITLE
using TMUX_BIN

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -8,12 +8,23 @@
 #   Version: 1.1.0 2022-04-13
 #
 
+#
+#  I use an env var TMUX_BIN to point at the current tmux, defined in my
+#  tmux.conf, in order to pick the version matching the server running.
+#  This is needed when checking backwards compatability with various versions.
+#  If not found, it is set to whatever is in path, so should have no negative
+#  impact. In all calls to tmux I use $TMUX_BIN instead in the rest of this
+#  plugin.
+#
+[ -z "$TMUX_BIN" ] && TMUX_BIN="tmux"
+
+
 get_tmux_option() {
     local option="$1"
     local default_value="${2-}"
     local option_value
 
-    option_value="$(tmux show-option -gqv "$option")"
+    option_value="$($TMUX_BIN show-option -gqv "$option")"
 
     if [[ -z "$option_value" ]]; then
         echo "$default_value"
@@ -27,7 +38,7 @@ set_tmux_option() {
     local option="$1"
     local value="$2"
 
-    tmux set-option -gq "$option" "$value"
+    $TMUX_BIN set-option -gq "$option" "$value"
 }
 
 


### PR DESCRIPTION
In order to be able to test various versions of tmux for compatibility with plugins, I used ASDF.
This has the drawback of using ~/.asdf/shims/tmux thus not allowing the path to tmux itself to identify what tmux to run, so I have set up my tmux.conf to identify the actual tmux in that case. When using ASDF the actual path to tmux (example: ~/.asdf/installs/tmux/2.8/bin/tmux) is identified and stored in the env variable TMUX_BIN

By using $TMUX_BIN whenever the plugin needs to access tmux from the shell, ensures that the plugin uses the tmux associated with the running session. This makes my testing much more convenient since I don't have to kill my main tmux each time I want to test a specific version, I just run a separate tmux under the version being tested.
This should not have any impact if TMUX_BIN is not used, since then it defaults to just being 'tmux'